### PR TITLE
add support for default values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: scala
 scala:
-- 2.11.8
+  - 2.11.8
 jdk:
-- oraclejdk8
+  - oraclejdk8
 sudo: false
+
+script:
+  - sbt clean
+  - sbt examples/test
+  - sbt test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ jdk:
 sudo: false
 
 script:
-  - sbt clean
   - sbt examples/test
   - sbt test

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Annotating any case class with `mappable` will generate a companion object (or e
 For details check out [MappableTest.scala](examples/src/test/scala/scala/meta/serialiser/MappableTest.scala)
 
 ## current limitations (a.k.a. TODOs)
+- not support `fromMap` for multiple constructor params lists
 
 # sbt command to compile and test this project
 ;clean;examples/clean;examples/test

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Annotating any case class with `mappable` will generate a companion object (or e
 
 For details check out [MappableTest.scala](examples/src/test/scala/scala/meta/serialiser/MappableTest.scala)
 
-## current limitations (a.k.a. TODOs)
+## current limitations (a.k.a. TODOs) 
 - not support `fromMap` for multiple constructor params lists
+- get maps of specific types
 
 # sbt command to compile and test this project
 ;clean;examples/clean;examples/test

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Annotating any case class with `mappable` will generate a companion object (or e
 For details check out [MappableTest.scala](examples/src/test/scala/scala/meta/serialiser/MappableTest.scala)
 
 ## current limitations (a.k.a. TODOs)
-* no support for default values -> information is available inside Term.Param (Trees.scala in scalameta repo)
 
 # sbt command to compile and test this project
 ;clean;examples/clean;examples/test

--- a/examples/src/test/scala/scala/meta/serialiser/MappableTest.scala
+++ b/examples/src/test/scala/scala/meta/serialiser/MappableTest.scala
@@ -57,12 +57,11 @@ class MappableTest extends WordSpec with Matchers {
     }
 
     "store correct defaultValueMap" in {
-      val testInstance = WithDefaultValue(s = "something")
       WithDefaultValue.defaultValueMap shouldBe (Map[String, Any]("i" -> 13))
     }
 
     "keep default value in fromMap" in {
-      val testInstance = WithDefaultValue(s = "something")
+      val testInstance = WithDefaultValue(s = "something") // with default i = 13
       val keyValue = Map[String, Any]("s" -> "something")
       WithDefaultValue.fromMap(keyValue) shouldBe Some(testInstance)
     }

--- a/examples/src/test/scala/scala/meta/serialiser/MappableTest.scala
+++ b/examples/src/test/scala/scala/meta/serialiser/MappableTest.scala
@@ -9,6 +9,7 @@ object TestEntities {
 
   object WithCompanion { def existingFun(): Int = 42 }
   @mappable case class WithCompanion (i: Int, s: String)
+  @mappable case class WithDefaultValue(i: Int = 13, s: String)
 }
 
 class MappableTest extends WordSpec with Matchers {
@@ -45,6 +46,25 @@ class MappableTest extends WordSpec with Matchers {
 
     "keep existing functionality in companion" in {
       WithCompanion.existingFun shouldBe 42
+    }
+  }
+
+  "case class with default" should {
+    "serialise and deserialise" in {
+      val testInstance = WithDefaultValue(s = "something")
+      val keyValue = WithDefaultValue.toMap(testInstance)
+      WithDefaultValue.fromMap(keyValue) shouldBe Some(testInstance)
+    }
+
+    "store defaultMap" in {
+      val testInstance = WithDefaultValue(s = "something")
+      WithDefaultValue.defaultMap shouldBe (Map[String, Any]("i" -> 13))
+    }
+
+    "keep default value in fromMap" in {
+      val testInstance = WithDefaultValue(s = "something")
+      val keyValue = Map[String, Any]("s" -> "something")
+      WithDefaultValue.fromMap(keyValue) shouldBe Some(testInstance)
     }
   }
 

--- a/examples/src/test/scala/scala/meta/serialiser/MappableTest.scala
+++ b/examples/src/test/scala/scala/meta/serialiser/MappableTest.scala
@@ -56,9 +56,9 @@ class MappableTest extends WordSpec with Matchers {
       WithDefaultValue.fromMap(keyValue) shouldBe Some(testInstance)
     }
 
-    "store defaultMap" in {
+    "store correct defaultValueMap" in {
       val testInstance = WithDefaultValue(s = "something")
-      WithDefaultValue.defaultMap shouldBe (Map[String, Any]("i" -> 13))
+      WithDefaultValue.defaultValueMap shouldBe (Map[String, Any]("i" -> 13))
     }
 
     "keep default value in fromMap" in {

--- a/src/main/scala/scala/meta/serialiser/mappable.scala
+++ b/src/main/scala/scala/meta/serialiser/mappable.scala
@@ -46,7 +46,7 @@ class mappable extends StaticAnnotation {
       val ctorValuesName: Term.Name = q"values"
 
       // get default value and store those value as a map in object
-      val defaultValue = paramss.flatten collect {
+      val defaultValue:  Seq[Term.ApplyInfix] = paramss.flatten collect {
         case param if param.default.nonEmpty =>
           q"""${param.name.value} -> ${param.default.get}"""
       }

--- a/src/main/scala/scala/meta/serialiser/mappable.scala
+++ b/src/main/scala/scala/meta/serialiser/mappable.scala
@@ -45,7 +45,8 @@ class mappable extends StaticAnnotation {
     object FromMap {
       val ctorValuesName: Term.Name = q"values"
 
-      val defaultMap = paramss.flatten collect {
+      // get default value and store those value as a map in object
+      val defaultValue = paramss.flatten collect {
         case param if param.default.nonEmpty =>
           q"""${param.name.value} -> ${param.default.get}"""
       }
@@ -63,12 +64,13 @@ class mappable extends StaticAnnotation {
       ..$mods class $tName[..$tParams](...$paramss) extends $template
 
       object $typeTermName {
-        val defaultMap: Map[String, Any] = Map(..${FromMap.defaultMap})
+        val defaultValueMap: Map[String, Any] = Map(..${FromMap.defaultValue})
+
         def toMap[..$tParams](${ToMap.mappableName}: ${Option(tCompleteType)}): Map[String, Any] =
           Map[String, Any](..${ToMap.keyValues(ToMap.mappableName)})
 
         def fromMap[..$tParams](v: Map[String, Any]): ${Option(tCompleteTypeOption)} = {
-            val values = defaultMap ++ v
+            val values = defaultValueMap ++ v
             scala.util.Try {
               ${tCompleteTerm}(..${FromMap.ctorArgs(FromMap.ctorValuesName)})
             }.toOption


### PR DESCRIPTION
add support for default values by store default values map in companion object. 
Map needed to recombine to case class will be added to default map before get class params.